### PR TITLE
NBody simulation.

### DIFF
--- a/examples/tests/nbody.cpp
+++ b/examples/tests/nbody.cpp
@@ -1,0 +1,107 @@
+#include "gtest/gtest.h"
+
+#include <gstorm.h>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include <CL/sycl.hpp>
+#include <range/v3/all.hpp>
+
+#include "experimental.h"
+#include "my_zip.h"
+
+struct NBody : public testing::Test {};
+
+using data_t = struct F4 {
+  F4() : x(0), y(0), z(0), w(0) {}
+  F4(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) {}
+  float x, y, z, w;
+};
+
+struct NBodyOperator {
+  float G, dt, eps2;
+
+  constexpr NBodyOperator(float G, float dt, float eps2)
+      : G{G}, dt{dt}, eps2{eps2} {};
+
+  template <typename T>
+  auto operator()(const T& tpl) const {
+    data_t a = {0.0f, 0.0f, 0.0f, 0.0f};
+    data_t r = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    auto p = *std::get<0>(tpl);
+    auto v = *std::get<1>(tpl);
+    auto& particles = std::get<2>(tpl);
+
+    for (auto& particle : particles) {
+      r.x = p.x - particle.x;
+      r.y = p.y - particle.y;
+      r.z = p.z - particle.z;
+      r.w = cl::sycl::sqrt(r.x * r.x + r.y * r.y + r.z * r.z + eps2);
+
+      a.w = G * particle.w * r.w * r.w * r.w;
+
+      a.x += a.w * r.x;
+      a.y += a.w * r.y;
+      a.z += a.w * r.z;
+    }
+
+    p.x += v.x * dt + a.x * 0.5f * dt * dt;
+    p.y += v.y * dt + a.y * 0.5f * dt * dt;
+    p.z += v.z * dt + a.z * 0.5f * dt * dt;
+
+    v.x += a.x * dt;
+    v.y += a.y * dt;
+    v.z += a.z * dt;
+
+    *std::get<1>(tpl) = v;
+    return p;
+  }
+};
+
+TEST_F(NBody, TestNBody) {
+  const size_t vsize = 1024;
+
+  std::default_random_engine generator;
+  std::uniform_real_distribution<float> distribution(-10.0, 10.0);
+
+  auto generate_float = [&generator, &distribution]() {
+    return distribution(generator);
+  };
+
+  auto generate_data_t = [&generate_float]() {
+    return data_t{generate_float(), generate_float(), generate_float(),
+                  generate_float()};
+  };
+
+  const auto G = -6.673e-11f;
+  const auto dt = 3600.f;
+  const auto eps2 = 0.00125f;
+
+  // Input to the SYCL device
+  std::vector<data_t> position(vsize);
+  std::vector<data_t> velocity(vsize);
+  std::vector<data_t> y(vsize);
+
+  ranges::generate(position, generate_data_t);
+  ranges::generate(position, generate_data_t);
+
+  {
+    gstorm::sycl_exec exec;
+
+    auto gpu_position = std::experimental::copy(exec, position);
+    auto gpu_velocity = std::experimental::copy(exec, velocity);
+    auto gpu_y = std::experimental::copy(exec, y);
+
+    auto repeated =
+        ranges::view::repeat_n(gstorm::gpu::ref(gpu_position), vsize);
+
+    auto zipped = my_zip(gpu_position, gpu_velocity, repeated);
+
+    std::experimental::transform(exec, zipped, gpu_y,
+                                 NBodyOperator{G, dt, eps2});
+  }
+
+  // EXPECT_TRUE(ranges::equal(expected, z));
+}

--- a/gstorm/include/detail/decorators/ref.h
+++ b/gstorm/include/detail/decorators/ref.h
@@ -55,14 +55,5 @@ namespace gstorm {
     auto ref(range::gvector <T>& ref) {
       return _gref_iterable<T>(ref);
     }
-
-    template<typename T>
-    const auto* gcopy(T cpy) {
-      auto& _buffer = pacxx::v2::get_executor().allocate<_gcopy<T>>(1);
-      _gcopy<T> tmp(cpy);
-      _buffer.upload(&tmp, 1);
-
-      return _buffer.get();
-    }
   }
 }

--- a/gstorm/include/detail/ranges/vector.h
+++ b/gstorm/include/detail/ranges/vector.h
@@ -46,7 +46,7 @@ template<typename T>
 struct gvector;
 
 template<typename T>
-struct iterator : public std::random_access_iterator_tag, public traits::range_forward_traits<T> {
+struct giterator : public std::random_access_iterator_tag, public traits::range_forward_traits<T> {
   using size_type = typename T::size_type;
   using value_type = typename T::value_type;
   using reference = std::conditional_t<std::is_const<T>::value,
@@ -63,21 +63,21 @@ struct iterator : public std::random_access_iterator_tag, public traits::range_f
                                                 cl::sycl::access::target::global_buffer,
                                                 cl::sycl::access::placeholder::true_t>;
 
-  iterator(size_t offset = 0, ptrdiff_t ref_back = 0) : accessor(), owner(ref_back), it(offset), id_(size_t_max) {
+  giterator(size_t offset = 0, ptrdiff_t ref_back = 0) : accessor(), owner(ref_back), it(offset), id_(size_t_max) {
 #ifndef __SYCL_DEVICE_ONLY__
     if (owner)
       id_ = (reinterpret_cast<gvector<T>*>(owner))->registerIterator(*this); // this should never be executed on the device
 #endif
   }
 
-  ~iterator(){
+  ~giterator(){
 #ifndef __SYCL_DEVICE_ONLY__
     if (owner && id_ != size_t_max)
       (reinterpret_cast<gvector<T>*>(owner))->forgetIterator(id_); // this should never be executed on the device
 #endif
   }
 
-  iterator(const iterator& other) : has_accessor(other.has_accessor), accessor(other.accessor), owner(other.owner), it(other.it), id_(){
+  giterator(const giterator& other) : has_accessor(other.has_accessor), accessor(other.accessor), owner(other.owner), it(other.it), id_(){
     if (!other.hasAccessor()) {
 #ifndef __SYCL_DEVICE_ONLY__
       if (owner)
@@ -92,7 +92,7 @@ struct iterator : public std::random_access_iterator_tag, public traits::range_f
 
   void setAccessor(sycl_accessor_type acc) { has_accessor = true; accessor = acc; }
 
-  explicit iterator(sycl_accessor_type acc, size_t offset = 0, ptrdiff_t ref_back = 0) :
+  explicit giterator(sycl_accessor_type acc, size_t offset = 0, ptrdiff_t ref_back = 0) :
     has_accessor(true),
     accessor(acc),
     owner(ref_back),
@@ -107,84 +107,84 @@ struct iterator : public std::random_access_iterator_tag, public traits::range_f
     return accessor[it];
   }
 
-  iterator &operator++() {
+  giterator &operator++() {
     ++it;
     return *this;
   }
 
-  iterator operator++(int) {
+  giterator operator++(int) {
     auto ip = it;
     ++it;
-    return iterator(accessor, ip, owner);
+    return giterator(accessor, ip, owner);
   }
 
-  iterator &operator--() {
+  giterator &operator--() {
     --it;
     return *this;
   }
 
-  iterator operator--(int) {
+  giterator operator--(int) {
     auto ip = it;
     --it;
-    return iterator(accessor, ip, owner);
+    return giterator(accessor, ip, owner);
   }
 
   reference operator[](difference_type n) { return accessor[it + n]; }
 
-  friend iterator advance(const iterator &lhs, difference_type n) {
+  friend giterator advance(const giterator &lhs, difference_type n) {
     return lhs.advance(n);
   }
 
-  iterator advance(difference_type n) {
+  giterator advance(difference_type n) {
     it += n;
     return *this;
   }
 
-  friend iterator operator+(const iterator &lhs, difference_type n) {
-    return iterator(lhs.accessor, lhs.it + n, lhs.owner);
+  friend giterator operator+(const giterator &lhs, difference_type n) {
+    return giterator(lhs.accessor, lhs.it + n, lhs.owner);
   }
 
-  friend iterator operator+(difference_type n, const iterator &rhs) {
-    return iterator(rhs.accessor, rhs.it + n, rhs.owner);
+  friend giterator operator+(difference_type n, const giterator &rhs) {
+    return giterator(rhs.accessor, rhs.it + n, rhs.owner);
   }
 
-  friend iterator operator-(const iterator &lhs, difference_type n) {
-    return iterator(lhs.accessor, lhs.it - n, lhs.owner);
+  friend giterator operator-(const giterator &lhs, difference_type n) {
+    return giterator(lhs.accessor, lhs.it - n, lhs.owner);
   }
 
-  friend difference_type operator-(const iterator &left, const iterator &right) {
+  friend difference_type operator-(const giterator &left, const giterator &right) {
     return left.it - right.it;
   }
 
-  friend iterator &operator-=(iterator &lhs, difference_type n) {
+  friend giterator &operator-=(giterator &lhs, difference_type n) {
     lhs.it -= n;
     return lhs;
   }
 
-  friend iterator &operator+=(iterator &lhs, difference_type n) {
+  friend giterator &operator+=(giterator &lhs, difference_type n) {
     lhs.it += n;
     return lhs;
   }
 
-  friend bool operator<(const iterator &left, const iterator &right) {
+  friend bool operator<(const giterator &left, const giterator &right) {
     return left.it < right.it;
   }
 
-  friend bool operator>(const iterator &left, const iterator &right) {
+  friend bool operator>(const giterator &left, const giterator &right) {
     return right < left;
   }
 
-  friend bool operator<=(const iterator &left, const iterator &right) {
+  friend bool operator<=(const giterator &left, const giterator &right) {
     return left < right || left == right;
   }
 
-  friend bool operator>=(const iterator &left, const iterator &right) {
+  friend bool operator>=(const giterator &left, const giterator &right) {
     return right < left || right == left;
   }
 
-  bool operator==(const iterator &other) const { return other.it == it; }
+  bool operator==(const giterator &other) const { return other.it == it; }
 
-  bool operator!=(const iterator &other) const { return !(other == *this); }
+  bool operator!=(const giterator &other) const { return !(other == *this); }
 
 private:
   bool has_accessor = false;
@@ -213,10 +213,10 @@ public:
                                                 cl::sycl::access::target::global_buffer,
                                                 cl::sycl::access::placeholder::true_t>;
 
+  using iterator = giterator<T>;
+  using sentinel = giterator<T>;
 
-  using sentinel = iterator<T>;
-
-  friend struct iterator<T>;
+  friend struct giterator<T>;
 
   gvector() : gvector_base(), _buffer(nullptr), _size(0) {}
 
@@ -270,32 +270,32 @@ public:
     return *this;
   }
 
-  iterator<T> begin() noexcept {
+  giterator<T> begin() noexcept {
     if (_cgh) {
-      return iterator<T>(getAccessor(_cgh, *_buffer), 0, reinterpret_cast<ptrdiff_t>(this));
+      return giterator<T>(getAccessor(_cgh, *_buffer), 0, reinterpret_cast<ptrdiff_t>(this));
     }
-    return iterator<T>(0, reinterpret_cast<ptrdiff_t>(this));
+    return giterator<T>(0, reinterpret_cast<ptrdiff_t>(this));
   }
 
-  iterator<T> end() noexcept {
+  giterator<T> end() noexcept {
     if (_cgh) {
-      return iterator<T>(getAccessor(_cgh, *_buffer), _size, reinterpret_cast<ptrdiff_t>(this));
+      return giterator<T>(getAccessor(_cgh, *_buffer), _size, reinterpret_cast<ptrdiff_t>(this));
     }
-    return iterator<T>(_size, reinterpret_cast<ptrdiff_t>(this));
+    return giterator<T>(_size, reinterpret_cast<ptrdiff_t>(this));
   }
 
-  const iterator<T> begin() const noexcept {
+  const giterator<T> begin() const noexcept {
     if (_cgh) {
-      return iterator<T>(getAccessor(_cgh, *_buffer), 0, reinterpret_cast<ptrdiff_t>(this));
+      return giterator<T>(getAccessor(_cgh, *_buffer), 0, reinterpret_cast<ptrdiff_t>(this));
     }
-    return iterator<T>(0, reinterpret_cast<ptrdiff_t>(this));
+    return giterator<T>(0, reinterpret_cast<ptrdiff_t>(this));
   }
 
-  const iterator<T> end() const noexcept {
+  const giterator<T> end() const noexcept {
     if (_cgh) {
-      return iterator<T>(getAccessor(_cgh, *_buffer), _size, reinterpret_cast<ptrdiff_t>(this));
+      return giterator<T>(getAccessor(_cgh, *_buffer), _size, reinterpret_cast<ptrdiff_t>(this));
     }
-    return iterator<T>(_size, reinterpret_cast<ptrdiff_t>(this));
+    return giterator<T>(_size, reinterpret_cast<ptrdiff_t>(this));
   }
 
   size_t size() const { return _size; }
@@ -325,7 +325,7 @@ protected:
   // an iterator has to register itself by its container
   // this is necessary to allow the container to update each iterator
   // as soon as the accessor is valid
-  auto registerIterator(iterator<T>& it) {
+  auto registerIterator(giterator<T>& it) {
     auto pair = std::make_pair(_iterators.size(), &it);
     _iterators.insert(pair);
     return pair.first;
@@ -358,7 +358,7 @@ private:
   }
 
   std::unique_ptr<cl::sycl::buffer <value_type>> _buffer;
-  std::map<size_t, iterator<T>*> _iterators;
+  std::map<size_t, giterator<T>*> _iterators;
   size_t _size;
 };
 

--- a/gstorm/include/gstorm.h
+++ b/gstorm/include/gstorm.h
@@ -12,6 +12,8 @@
 
 #include <meta/executor.h>
 
+#include <detail/decorators/ref.h>
+
 // algorithms
 #include <detail/algorithms/transform.h>
 //#include <detail/algorithms/reduce.h>


### PR DESCRIPTION
Add an implementation of NBody simulation.

To be able to add it, also renamed `iterator` to `giterator` and added a type alias for it to be able to use `gstorm::gpu::ref`.